### PR TITLE
Fix BitShift

### DIFF
--- a/src/tests/test_utils/test_math_utils.cairo
+++ b/src/tests/test_utils/test_math_utils.cairo
@@ -4,7 +4,7 @@ use integer::BoundedInt;
 #[test]
 #[available_gas(2000000)]
 fn test_shift_left_u256_1() {
-    let mut input: u256 = 1;
+    let input: u256 = 1;
     let result = input.shl(1);
     assert(result == 2, 'test_shift_left_1');
 }
@@ -12,7 +12,7 @@ fn test_shift_left_u256_1() {
 #[test]
 #[available_gas(2000000)]
 fn test_shift_left_u256_zero() {
-    let mut input: u256 = 0;
+    let input: u256 = 0;
     let result = input.shl(5);
     assert(result == 0, 'test_shift_left_zero');
 }
@@ -20,7 +20,7 @@ fn test_shift_left_u256_zero() {
 #[test]
 #[available_gas(2000000)]
 fn test_shift_right_u256_1() {
-    let mut input: u256 = 4;
+    let input: u256 = 4;
     let result = input.shr(1);
     assert(result == 2, 'test_shift_left_zero');
 }
@@ -28,7 +28,7 @@ fn test_shift_right_u256_1() {
 #[test]
 #[available_gas(2000000)]
 fn test_shift_right_u256_max() {
-    let mut input: u256 = BoundedInt::max();
+    let input: u256 = BoundedInt::max();
     let result = input.shr(1);
     assert(result == BoundedInt::max() / 2, 'test_shift_left_zero');
 }
@@ -36,7 +36,7 @@ fn test_shift_right_u256_max() {
 #[test]
 #[available_gas(2000000)]
 fn test_shift_right_u256_zero() {
-    let mut input: u256 = 0;
+    let input: u256 = 0;
     let result = input.shr(5);
     assert(result == 0, 'test_shift_left_zero');
 }
@@ -55,7 +55,7 @@ fn test_shift_right_u256_zero() {
 #[test]
 #[available_gas(2000000)]
 fn test_shift_left_u32_1() {
-    let mut input: u32 = 1;
+    let input: u32 = 1;
     let result = input.shl(1);
     assert(result == 2, 'test_shift_left_1');
 }
@@ -63,7 +63,7 @@ fn test_shift_left_u32_1() {
 #[test]
 #[available_gas(2000000)]
 fn test_shift_left_u32_zero() {
-    let mut input: u256 = 0;
+    let input: u256 = 0;
     let result = input.shl(5);
     assert(result == 0, 'test_shift_left_zero');
 }
@@ -71,7 +71,7 @@ fn test_shift_left_u32_zero() {
 #[test]
 #[available_gas(2000000)]
 fn test_shift_right_u32_1() {
-    let mut input: u32 = 4;
+    let input: u32 = 4;
     let result = input.shr(1);
     assert(result == 2, 'test_shift_left_zero');
 }
@@ -79,7 +79,7 @@ fn test_shift_right_u32_1() {
 #[test]
 #[available_gas(2000000)]
 fn test_shift_right_u32_max() {
-    let mut input: u32 = BoundedInt::max();
+    let input: u32 = BoundedInt::max();
     let result = input.shr(1);
     assert(result == BoundedInt::max() / 2, 'test_shift_left_zero');
 }
@@ -87,7 +87,7 @@ fn test_shift_right_u32_max() {
 #[test]
 #[available_gas(2000000)]
 fn test_shift_right_u32_zero() {
-    let mut input: u32 = 0;
+    let input: u32 = 0;
     let result = input.shr(5);
     assert(result == 0, 'test_shift_left_zero');
 }

--- a/src/utils/math_utils.cairo
+++ b/src/utils/math_utils.cairo
@@ -3,31 +3,31 @@ mod MathUtils {
     use option::OptionTrait;
 
     trait BitShiftTrait<T> {
-        fn shl(ref self: T, n: T) -> T;
-        fn shr(ref self: T, n: T) -> T;
+        fn shl(self: @T, n: T) -> T;
+        fn shr(self: @T, n: T) -> T;
     }
 
     impl U256BitShift of BitShiftTrait<u256> {
         #[inline(always)]
-        fn shl(ref self: u256, n: u256) -> u256 {
-            self * pow(2, n)
+        fn shl(self: @u256, n: u256) -> u256 {
+            *self * pow(2, n)
         }
 
         #[inline(always)]
-        fn shr(ref self: u256, n: u256) -> u256 {
-            self / pow(2, n)
+        fn shr(self: @u256, n: u256) -> u256 {
+            *self / pow(2, n)
         }
     }
 
     impl U32BitShift of BitShiftTrait<u32> {
         #[inline(always)]
-        fn shl(ref self: u32, n: u32) -> u32 {
-            self * pow(2, n.into()).try_into().unwrap()
+        fn shl(self: @u32, n: u32) -> u32 {
+            *self * pow(2, n.into()).try_into().unwrap()
         }
 
         #[inline(always)]
-        fn shr(ref self: u32, n: u32) -> u32 {
-            self / pow(2, n.into()).try_into().unwrap()
+        fn shr(self: @u32, n: u32) -> u32 {
+            *self / pow(2, n.into()).try_into().unwrap()
         }
     }
 


### PR DESCRIPTION
With `ref` I'm forcing the variable to be mutable in order to use the `BitShift`. In our case, we're not going to modify the number; we're going to return a new one. Using `ref` doesn't make sense