### PR TITLE
Add contract AMM

### DIFF
--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -4,3 +4,6 @@ mod utils;
 
 #[cfg(test)]
 mod tests;
+
+// This contract is only used to follow the tutorial in the readme 'Declare and Deploy Contracts'
+mod amm;


### PR DESCRIPTION
This contract is only used to follow the tutorial in the readme 'Declare and Deploy Contracts'

Closes: #67 