### PR TITLE
Chore remove unnecessary import

### DIFF
--- a/src/libraries/bit_math.cairo
+++ b/src/libraries/bit_math.cairo
@@ -1,7 +1,6 @@
 mod BitMath {
     use integer::{U256BitAnd, Felt252IntoU256};
-    use traits::{TryInto, DivEq};
-    use option::OptionTrait;
+    use traits::DivEq;
 
     /// @notice Returns the index of the most significant bit of the number,
     ///     where the least significant bit is at index 0 and the most significant bit is at index 255

--- a/src/libraries/liquidity_math.cairo
+++ b/src/libraries/liquidity_math.cairo
@@ -1,9 +1,6 @@
-use core::result::ResultTrait;
 /// Math library for liquidity
 mod LiquidityMath {
     use core::traits::PartialOrd;
-    use result::Result;
-    use result::ResultTrait;
     use core::integer::u128_overflowing_add;
     use orion::numbers::signed_integer::i128::i128;
     use orion::numbers::signed_integer::integer_trait::IntegerTrait;

--- a/src/libraries/liquidity_math.cairo
+++ b/src/libraries/liquidity_math.cairo
@@ -1,10 +1,7 @@
 use core::result::ResultTrait;
 /// Math library for liquidity
 mod LiquidityMath {
-    use traits::Into;
-    use traits::TryInto;
     use core::traits::PartialOrd;
-    use option::OptionTrait;
     use result::Result;
     use result::ResultTrait;
     use core::integer::u128_overflowing_add;

--- a/src/libraries/sqrt_price_math.cairo
+++ b/src/libraries/sqrt_price_math.cairo
@@ -12,8 +12,6 @@ mod SqrtPriceMath {
     use orion::numbers::signed_integer::integer_trait::IntegerTrait;
 
     use yas::utils::math_utils::MathUtils::pow;
-    use traits::{Into, TryInto};
-    use option::OptionTrait;
 
     /// Returns the next square root price given a token0 delta.
     /// @param sqrtPX96 The initial price (prior to considering the token0 delta).

--- a/src/libraries/swap_math.cairo
+++ b/src/libraries/swap_math.cairo
@@ -13,7 +13,6 @@ mod SwapMath {
     };
     use integer::{u256_overflowing_add, u256_overflow_mul};
     use orion::numbers::signed_integer::integer_trait::IntegerTrait;
-    use option::OptionTrait;
 
     const _1e6: u256 = 1000000; // 10 ** 6 
 

--- a/src/libraries/tick.cairo
+++ b/src/libraries/tick.cairo
@@ -58,7 +58,6 @@ mod Tick {
     use super::{ITick, Info};
 
     use poseidon::poseidon_hash_span;
-    use serde::Serde;
     use integer::BoundedInt;
 
     use orion::numbers::signed_integer::{i32::i32, i64::i64, i128::i128};

--- a/src/libraries/tick.cairo
+++ b/src/libraries/tick.cairo
@@ -57,11 +57,8 @@ trait ITick<TStorage> {
 mod Tick {
     use super::{ITick, Info};
 
-    use array::ArrayTrait;
-    use option::OptionTrait;
     use poseidon::poseidon_hash_span;
     use serde::Serde;
-    use traits::{Into, TryInto};
     use integer::BoundedInt;
 
     use orion::numbers::signed_integer::{i32::i32, i64::i64, i128::i128};

--- a/src/libraries/tick_bitmap.cairo
+++ b/src/libraries/tick_bitmap.cairo
@@ -17,7 +17,6 @@ mod TickBitmap {
 
     use integer::BoundedInt;
     use poseidon::poseidon_hash_span;
-    use serde::Serde;
 
     use orion::numbers::signed_integer::i32::i32;
     use orion::numbers::signed_integer::i16::i16;

--- a/src/libraries/tick_bitmap.cairo
+++ b/src/libraries/tick_bitmap.cairo
@@ -15,12 +15,9 @@ trait ITickBitmap<TStorage> {
 mod TickBitmap {
     use super::ITickBitmap;
 
-    use array::ArrayTrait;
     use integer::BoundedInt;
-    use option::{OptionTrait};
     use poseidon::poseidon_hash_span;
     use serde::Serde;
-    use traits::{Into, TryInto};
 
     use orion::numbers::signed_integer::i32::i32;
     use orion::numbers::signed_integer::i16::i16;

--- a/src/numbers/fixed_point/implementations/impl_64x96.cairo
+++ b/src/numbers/fixed_point/implementations/impl_64x96.cairo
@@ -1,6 +1,4 @@
 use debug::PrintTrait;
-use option::OptionTrait;
-use traits::{Into, TryInto};
 
 use yas::numbers::fixed_point::core::{FixedTrait, FixedType};
 use yas::numbers::fixed_point::math::math_64x96;

--- a/src/numbers/fixed_point/math/math_64x96.cairo
+++ b/src/numbers/fixed_point/math/math_64x96.cairo
@@ -1,7 +1,3 @@
-use core::debug::PrintTrait;
-use option::OptionTrait;
-use traits::{Into, TryInto};
-
 use yas::numbers::fixed_point::core::{FixedTrait, FixedType};
 use yas::numbers::fixed_point::implementations::impl_64x96::{ONE, ONE_u128, MAX, HALF};
 use yas::numbers::fixed_point::implementations::impl_64x96::{

--- a/src/numbers/signed_integer/i256.cairo
+++ b/src/numbers/signed_integer/i256.cairo
@@ -1,5 +1,3 @@
-use traits::Into;
-
 use orion::numbers::signed_integer::integer_trait::IntegerTrait;
 use integer::{BoundedInt, u256_wide_mul};
 // ====================== INT 256 ======================

--- a/src/tests/test_libraries/test_sqrt_price_math.cairo
+++ b/src/tests/test_libraries/test_sqrt_price_math.cairo
@@ -3,7 +3,6 @@ mod TestSqrtPriceMath {
     use yas::numbers::fixed_point::implementations::impl_64x96::{
         FP64x96Impl, FP64x96Div, FixedType, FixedTrait, Q96_RESOLUTION, ONE, MAX
     };
-    use traits::Into;
     use integer::{u256_sqrt, u256_safe_div_rem, u256_try_as_non_zero};
 
     // Aux methods for tests
@@ -38,8 +37,6 @@ mod TestSqrtPriceMath {
             FP64x96Impl, FP64x96PartialEq, FixedType, FixedTrait, Q96_RESOLUTION
         };
         use integer::BoundedInt;
-        use traits::{Into, TryInto};
-        use option::OptionTrait;
 
         // fails if price is zero
         #[test]
@@ -191,8 +188,6 @@ mod TestSqrtPriceMath {
             FP64x96Impl, FP64x96PartialEq, FixedType, FixedTrait, Q96_RESOLUTION
         };
         use integer::BoundedInt;
-        use option::OptionTrait;
-        use traits::{Into, TryInto};
 
         // fails if price is zero
         #[test]
@@ -360,8 +355,6 @@ mod TestSqrtPriceMath {
             FP64x96Impl, FP64x96PartialEq, FixedType, FixedTrait, Q96_RESOLUTION
         };
         use yas::utils::math_utils::MathUtils::pow;
-        use option::OptionTrait;
-        use traits::{Into, TryInto};
 
         // returns 0 if liquidity is 0
         #[test]
@@ -439,8 +432,6 @@ mod TestSqrtPriceMath {
             FP64x96Impl, FP64x96PartialEq, FixedType, FixedTrait, Q96_RESOLUTION
         };
         use yas::utils::math_utils::MathUtils::pow;
-        use option::OptionTrait;
-        use traits::{Into, TryInto};
 
         // returns 0 if liquidity is 0
         #[test]

--- a/src/tests/test_libraries/test_swap_math.cairo
+++ b/src/tests/test_libraries/test_swap_math.cairo
@@ -3,7 +3,6 @@ mod TestSwapMath {
     use yas::numbers::fixed_point::implementations::impl_64x96::{
         FP64x96Impl, FP64x96Div, FixedType, FixedTrait, Q96_RESOLUTION, ONE, MAX
     };
-    use traits::Into;
 
     fn expand_to_18_decimals(n: u256) -> u256 {
         n * pow(10, 18)

--- a/src/tests/test_libraries/test_tick.cairo
+++ b/src/tests/test_libraries/test_tick.cairo
@@ -1,8 +1,5 @@
 mod TickTests {
-    use array::ArrayTrait;
     use result::ResultTrait;
-    use traits::{Into, TryInto};
-    use option::OptionTrait;
     use starknet::syscalls::deploy_syscall;
 
     use orion::numbers::signed_integer::i32::i32;

--- a/src/tests/test_libraries/test_tick.cairo
+++ b/src/tests/test_libraries/test_tick.cairo
@@ -1,5 +1,4 @@
 mod TickTests {
-    use result::ResultTrait;
     use starknet::syscalls::deploy_syscall;
 
     use orion::numbers::signed_integer::i32::i32;

--- a/src/tests/test_libraries/test_tick_bitmap.cairo
+++ b/src/tests/test_libraries/test_tick_bitmap.cairo
@@ -1,8 +1,5 @@
 mod TickBitmapTests {
-    use array::ArrayTrait;
     use result::ResultTrait;
-    use traits::{Into, TryInto};
-    use option::OptionTrait;
     use starknet::syscalls::deploy_syscall;
 
     use orion::numbers::signed_integer::i32::i32;

--- a/src/tests/test_libraries/test_tick_bitmap.cairo
+++ b/src/tests/test_libraries/test_tick_bitmap.cairo
@@ -1,5 +1,4 @@
 mod TickBitmapTests {
-    use result::ResultTrait;
     use starknet::syscalls::deploy_syscall;
 
     use orion::numbers::signed_integer::i32::i32;

--- a/src/tests/test_numbers/test_fixed_point/test_fp64x96.cairo
+++ b/src/tests/test_numbers/test_fixed_point/test_fp64x96.cairo
@@ -1,6 +1,3 @@
-use option::OptionTrait;
-use traits::{Into, TryInto};
-
 use yas::numbers::fixed_point::core::{FixedTrait, FixedType};
 use yas::numbers::fixed_point::implementations::impl_64x96::{
     ONE_u128, ONE, MAX, _felt_abs, _felt_sign, FP64x96Impl, FP64x96Into, FP64x96Add, FP64x96AddEq,

--- a/src/utils/fullmath.cairo
+++ b/src/utils/fullmath.cairo
@@ -2,7 +2,6 @@ mod FullMath {
     use integer::{
         BoundedInt, u256_wide_mul, u256_safe_divmod, u512_safe_div_rem_by_u256, u256_try_as_non_zero
     };
-    use option::OptionTrait;
 
     // Multiplies two u256 numbers and divides the result by a third.
     // Credits to sphinx-protocol

--- a/src/utils/math_utils.cairo
+++ b/src/utils/math_utils.cairo
@@ -1,6 +1,4 @@
 mod MathUtils {
-    use traits::{Into, TryInto};
-    use option::OptionTrait;
     use integer::BoundedInt;
     use orion::numbers::signed_integer::integer_trait::IntegerTrait;
     use orion::numbers::signed_integer::i32::{i32, ensure_non_negative_zero, i32_check_sign_zero};

--- a/src/utils/orion_utils.cairo
+++ b/src/utils/orion_utils.cairo
@@ -1,7 +1,5 @@
 mod OrionUtils {
     use integer::BoundedInt;
-    use option::{OptionTrait};
-    use traits::{Into, TryInto};
 
     use orion::numbers::signed_integer::i32::i32;
     use orion::numbers::signed_integer::i16::i16;


### PR DESCRIPTION
With Cairo V2.2.0, these imports are no longer necessary
```
use traits::Into;
use traits::TryInto;
use option::OptionTrait;
use array::ArrayTrait;
```

Closes: #73 


