### PR TITLE
refactored tick to add default to struct Info

### DIFF
--- a/src/libraries/tick.cairo
+++ b/src/libraries/tick.cairo
@@ -57,6 +57,7 @@ trait ITick<TContractState> {
         upper: bool,
         max_liquidity: u128
     ) -> bool;
+    fn default_tick_info() -> Info;
 }
 
 #[starknet::contract]
@@ -104,20 +105,12 @@ mod Tick {
         /// @param tick The tick that will be cleared
         fn clear(ref self: ContractState, tick: i32) {
             let hashed_tick = PoseidonTrait::new().update_with(tick).finalize();
+            let default_info = default_tick_info();
             self
                 .ticks
                 .write(
                     hashed_tick,
-                    Info {
-                        liquidity_gross: 0,
-                        liquidity_net: IntegerTrait::<i128>::new(0, false),
-                        fee_growth_outside_0X128: 0,
-                        fee_growth_outside_1X128: 0,
-                        tick_cumulative_outside: IntegerTrait::<i64>::new(0, false),
-                        seconds_per_liquidity_outside_X128: 0,
-                        seconds_outside: 0,
-                        initialized: false
-                    }
+                    default_info
                 );
         }
 
@@ -272,6 +265,20 @@ mod Tick {
             self.ticks.write(hashed_tick, info);
             flipped
         }
+
+        /// @notice default tick data
+        fn default_tick_info() -> Info {
+           Info {
+                    liquidity_gross: 0,
+                    liquidity_net: IntegerTrait::<i128>::new(0, false),
+                    fee_growth_outside_0X128: 0,
+                    fee_growth_outside_1X128: 0,
+                    tick_cumulative_outside: IntegerTrait::<i64>::new(0, false),
+                    seconds_per_liquidity_outside_X128: 0,
+                    seconds_outside: 0,
+                    initialized: false
+                } 
+        };
     }
 
     #[generate_trait]


### PR DESCRIPTION
I added a default_tick_info trait which sets all the field of the struct Info to zero and made the clear to use it