### PR TITLE
Add clean target to Makefile

### DIFF
--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Install Semgrep
         run: |
-          pip install semgrep
+          pip install semgrep==1.45.0
       - name: Run Semgrep
         run: semgrep --config https://github.com/avnu-labs/semgrep-cairo-rules/releases/download/v0.0.1/cairo-rules.yaml ./crates > semgrep-output.txt
       - name: Save Semgrep Output as an Artifact

--- a/Makefile
+++ b/Makefile
@@ -17,16 +17,18 @@ install-dojo:
 start-katana:
 	katana
 
-build:
+clean:
+	scarb clean
+
+build: clean
 	scarb build
 
-deploy:
+deploy: clean
 	cargo run --bin deploy
 	
-demo-local:
+demo-local: clean
 	cargo run --bin local
 	
-
 Command := $(firstword $(MAKECMDGOALS))
 FILTER := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
 test:


### PR DESCRIPTION
There was a bug found after the latest refactor in which the `deploy` and `local` scripts didn't worked. This happened because the test before merging wasn't done with the latest contracts but instead done with the old contracts compiled in `target`.
To avoid this issue in the future, this PR adds `make clean` and this will be run on every `build` and `demo-local`.