### PR TITLE
Fix CI by reverting the Semgrep version to 1.45.0

### DIFF
--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Install Semgrep
         run: |
-          pip install semgrep
+          pip install semgrep==1.45.0  
       - name: Run Semgrep
         run: semgrep --config https://github.com/avnu-labs/semgrep-cairo-rules/releases/download/v0.0.1/cairo-rules.yaml ./crates > semgrep-output.txt
       - name: Save Semgrep Output as an Artifact

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Install Semgrep
         run: |
-          pip install semgrep==1.45.0  
+          pip install semgrep==1.45.0
       - name: Run Semgrep
         run: semgrep --config https://github.com/avnu-labs/semgrep-cairo-rules/releases/download/v0.0.1/cairo-rules.yaml ./crates > semgrep-output.txt
       - name: Save Semgrep Output as an Artifact


### PR DESCRIPTION
The[ latests release from Semgrep](https://github.com/returntocorp/semgrep/releases/tag/v1.46.0) seems to have introduced a breaking change in our static code analysis env.
This PR reverts the semgrep version to 1.45.0 used in the CI to return to a working version.
